### PR TITLE
Make png path optional. If no png path given, use pdf path and replace extension.

### DIFF
--- a/src/pdftopng/cli.py
+++ b/src/pdftopng/cli.py
@@ -9,12 +9,16 @@ from . import __version__
 @click.command("pdftopng")
 @click.version_option(version=__version__)
 @click.argument("pdf_path", type=click.Path(exists=True))
-@click.argument("png_path")
+@click.argument("png_path", required=False)
 @click.pass_context
 def cli(ctx, *args, **kwargs):
     """A PDF to PNG conversion tool (based on `pdftoppm` from `poppler`)"""
 
     pdf_path = kwargs["pdf_path"]
     png_path = kwargs["png_path"]
+
+    # If no png path is given, use pdf path and replace extension.
+    if png_path is None:
+        png_path = pdf_path.rsplit(".", 1)[0] + '.png'
 
     pdftopng.convert(pdf_path=pdf_path, png_path=png_path)


### PR DESCRIPTION
Usually I always want to have the same filename for the pngs as for the pdfs, except for the file extension.
When I'm using this via CLI, I always have to pass the pdf paths, which is cumbersome in my use case.

This PR makes the png path optional to increase usability.
If there's no png path given, use pdf path and replace extension.

example:
```
pdftopng example.pdf
```
will create the file `example.png`

