### PR TITLE
Extend explicit mac machine list for arm and amd64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ env:
   CIBW_BEFORE_BUILD_LINUX: "sh scripts/build_linux.sh"
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=$(pwd)/lib/poppler/build/:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel}"
   CIBW_BEFORE_BUILD_MACOS: "sh scripts/build_macos.sh"
-  CIBW_REPAIR_WHEEL_COMMAND_MACOS: "MACOSX_DEPLOYMENT_TARGET=14.0 DYLD_LIBRARY_PATH=$(pwd)/lib/poppler/build:$DYLD_LIBRARY_PATH delocate-wheel -w {dest_dir} -v {wheel}"
+  CIBW_REPAIR_WHEEL_COMMAND_MACOS: "MACOSX_DEPLOYMENT_TARGET=\"$(sw_vers --productVersion | cut -c1-2).0\" DYLD_LIBRARY_PATH=$(pwd)/lib/poppler/build:$DYLD_LIBRARY_PATH delocate-wheel -w {dest_dir} -v {wheel}"
   # CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "call scripts/wheel_repair.bat {wheel} {dest_dir}"
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-13-large, macos-14, macos-14-large, macos-15, macos-15-large]
         python-version: ["3.13"]
 
     steps:


### PR DESCRIPTION
Hello!

I've added the explicit list to support various versions of wheels for different Mac versions 13, 14, 15 and arm/amd. I've removed `macos-latest`, because of the possible duplication. It looks like this list anyway should be updated manually with new versions released in GitHub flow.